### PR TITLE
Added: I have added the condition in the function _mintMinerReward

### DIFF
--- a/ocean-token/contracts/OceanToken.sol
+++ b/ocean-token/contracts/OceanToken.sol
@@ -11,23 +11,41 @@ contract OceanToken is ERC20Capped, ERC20Burnable {
     address payable public owner;
     uint256 public blockReward;
 
-    constructor(uint256 cap, uint256 reward) ERC20("OceanToken", "OCT") ERC20Capped(cap * (10 ** decimals())) {
+    constructor(
+        uint256 cap,
+        uint256 reward
+    ) ERC20("OceanToken", "OCT") ERC20Capped(cap * (10 ** decimals())) {
         owner = payable(msg.sender);
         _mint(owner, 70000000 * (10 ** decimals()));
         blockReward = reward * (10 ** decimals());
     }
 
-    function _mint(address account, uint256 amount) internal virtual override(ERC20Capped, ERC20) {
-        require(ERC20.totalSupply() + amount <= cap(), "ERC20Capped: cap exceeded");
+    function _mint(
+        address account,
+        uint256 amount
+    ) internal virtual override(ERC20Capped, ERC20) {
+        require(
+            ERC20.totalSupply() + amount <= cap(),
+            "ERC20Capped: cap exceeded"
+        );
         super._mint(account, amount);
     }
 
     function _mintMinerReward() internal {
-        _mint(block.coinbase, blockReward);
+        if (ERC20.totalSupply() <= (80000000 * (10 ** decimals())))
+            _mint(block.coinbase, blockReward);
     }
 
-    function _beforeTokenTransfer(address from, address to, uint256 value) internal virtual override {
-        if(from != address(0) && to != block.coinbase && block.coinbase != address(0)) {
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 value
+    ) internal virtual override {
+        if (
+            from != address(0) &&
+            to != block.coinbase &&
+            block.coinbase != address(0)
+        ) {
             _mintMinerReward();
         }
         super._beforeTokenTransfer(from, to, value);
@@ -41,7 +59,7 @@ contract OceanToken is ERC20Capped, ERC20Burnable {
         selfdestruct(owner);
     }
 
-    modifier onlyOwner {
+    modifier onlyOwner() {
         require(msg.sender == owner, "Only the owner can call this function");
         _;
     }


### PR DESCRIPTION
Since this function is automatically called before the token transfer, it means that before every transfer, tokens are minted equal to the blockReward to reward the miner. In this scenario, after a certain number of transactions, the totalSupply will reach its maximum cap, resulting in no more rewards or minting of the token. For example, let's consider the following parameters: blockReward = 100 and Initial totalSupply = 70,000,000. After the first transfer, the totalSupply will increase to 70,000,100. After another 299,999 transfers, the totalSupply will reach 100,000,000. Therefore, there are only 300,000 successful transfers allowed. The 300,001st transfer will be reverted with an error message stating 'Maximum capped amount is reached.' To avoid this situation, it is essential to set the following condition as added to the code.